### PR TITLE
Separating The CLI Tool From The Package

### DIFF
--- a/bin/lazycred
+++ b/bin/lazycred
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+import lazycred
+import sys
+
+if __name__ == '__main__':
+
+    # ensure the correct number of command line arguments
+    if len(sys.argv) <= 2:
+        print(
+            "Usage:\n\tlazycred.py <operation> <operand> [file]\n\n"
+            "Operations:\n"
+            "\tget - get the credentials stored under a key\n"
+            "\t      identified by [operand]\n"
+            "\tput - put the credentials from the standard\n"
+            "\t      input or [file] under a key identified by [operand]\n"
+            )
+        exit(1)
+
+    # process command line arguments
+    operation, operand = sys.argv[1:3]
+
+    if operation == 'put':
+        if len(sys.argv) > 3:
+            with open(sys.argv[3], 'r') as stream:
+                data = stream.read()
+        else:
+            data = sys.stdin.read()
+        lazycred.put(operand, data)
+    elif operation == 'get':
+        result = lazycred.get(operand)
+        if result:
+            print(result)
+    else:
+        print("Unrecognized operation {!r}.".format(operation))

--- a/bin/lazycred
+++ b/bin/lazycred
@@ -8,7 +8,7 @@ if __name__ == '__main__':
     # ensure the correct number of command line arguments
     if len(sys.argv) <= 2:
         print(
-            "Usage:\n\tlazycred.py <operation> <operand> [file]\n\n"
+            "Usage:\n\tlazycred <operation> <operand> [file]\n\n"
             "Operations:\n"
             "\tget - get the credentials stored under a key\n"
             "\t      identified by [operand]\n"

--- a/lazycred/__init__.py
+++ b/lazycred/__init__.py
@@ -1,0 +1,3 @@
+from lazycred import get
+from lazycred import put
+from lazycred import aws_config

--- a/lazycred/__init__.py
+++ b/lazycred/__init__.py
@@ -1,3 +1,1 @@
-from lazycred import get
-from lazycred import put
-from lazycred import aws_config
+from lazycred import get, put, aws_config

--- a/lazycred/lazycred.py
+++ b/lazycred/lazycred.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 LazyCred
 """
@@ -10,7 +8,6 @@ from cryptography.fernet import Fernet
 import json
 import logging
 import os
-import sys
 
 LAZYCRED_LOG_NAME = 'LazyCredLogger'
 LOCAL_CONFIG_FILE = '.lazycred'
@@ -271,33 +268,3 @@ def put(key, data):
             return True
     return False
 
-if __name__ == '__main__':
-
-    # ensure the correct number of command line arguments
-    if len(sys.argv) <= 2:
-        print(
-            "Usage:\n\tlazycred.py <operation> <operand> [file]\n\n"
-            "Operations:\n"
-            "\tget - get the credentials stored under a key\n"
-            "\t      identified by [operand]\n"
-            "\tput - put the credentials from the standard\n"
-            "\t      input or [file] under a key identified by [operand]\n"
-            )
-        exit(1)
-
-    # process command line arguments
-    operation, operand = sys.argv[1:3]
-
-    if operation == 'put':
-        if len(sys.argv) > 3:
-            with open(sys.argv[3], 'r') as stream:
-                data = stream.read()
-        else:
-            data = sys.stdin.read()
-        put(operand, data)
-    elif operation == 'get':
-        result = get(operand)
-        if result:
-            print(result)
-    else:
-        print("Unrecognized operation {!r}.".format(operation))

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(
     author_email='val@tenyotk.in',
     url='https://github.com/2deviant/LazyCred',
     packages=['lazycred'],
-    scripts=['lazycred/lazycred.py']
+    scripts=['bin/lazycred']
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='lazycred',
-    version='0.1.0',
+    version='0.2.1',
     description='Minimalistic Credentials Manager based on AWS.',
     author='Val Tenyotkin',
     author_email='val@tenyotk.in',


### PR DESCRIPTION
# Summary
## Separating CLI Tool and Package
Separating the CLI tool `lazycred` from the package `lazycred.py`, which used to be one file and the two were differentiated with:
```python
if __name__ == '__main__':
    ...
```
## Export Bug Fix
Forgot to export `get()`, `put()`, and `aws_config`.
